### PR TITLE
adjust handling of snippet variable in GET snippet/:id route

### DIFF
--- a/routes/snippet.js
+++ b/routes/snippet.js
@@ -66,14 +66,14 @@ route.get('/', (req, res) => {
  */
 route.get('/:id', (req, res) => {
   const snippetId = parseInt(req.params.id)
-  const snippet = snippets.find(snippet => snippet.id === snippetId)
+  let snippet = snippets.find(snippet => snippet.id === snippetId)
 
   if (!snippet) {
     return res.status(404).json({ error: 'Snippet not found' })
   }
 
   // decrypt before sending back
-  snippet.code = decrypt(snippet.code)
+  snippet = {...snippet, 'code': decrypt(snippet.code)}
   res.json(snippet)
 })
 


### PR DESCRIPTION
adjust snippet variable in GET snippet/:id route to only change the snippet variable when decrypting (send back decrypted code), but not the entire snippets array (don't decrypt what's stored in the array)